### PR TITLE
Read data from bilby pickles

### DIFF
--- a/heron/bilby.py
+++ b/heron/bilby.py
@@ -1,0 +1,25 @@
+"""
+Interfaces with the bilby library
+---------------------------------
+
+This file contains code to allow heron to interface with bilby,
+including reading bilby data files.
+"""
+
+import pickle
+import bilby_pipe
+
+def read_pickle(filename):
+    """
+    Read a data pickle created by bilby_pipe_generation.
+    """
+    output = {}
+    with open(filename, "rb") as pickle_file:
+        data = pickle.load(pickle_file)
+
+    output['strain'] = {}
+
+    for ifo in data.interferometers:
+        output['strain'][ifo.name] = ifo.time_domain_strain
+
+    return output

--- a/heron/bilby.py
+++ b/heron/bilby.py
@@ -12,6 +12,19 @@ import bilby_pipe
 def read_pickle(filename):
     """
     Read a data pickle created by bilby_pipe_generation.
+
+    Parameters
+    ----------
+    filename : str
+       The path to the file to be read to provide strain data.
+
+    Notes
+    -----
+
+    At present this function only returns the strain data.
+    Other information is also stored in the pickle, and this could
+    also be extracted, but in order to use bilby to e.g. perform
+    injections we currently only need this.
     """
     output = {}
     with open(filename, "rb") as pickle_file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ elk-waveform
 gpytorch==1.0.1
 torch==2.4.0
 torchvision==0.5.0
+bilby_pipe

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,5 @@ nessai
 elk-waveform
 gpytorch==1.0.1
 torch==2.4.0
-torchvision==0.5.0
+torchvision
 bilby_pipe

--- a/tests/test_bilby.py
+++ b/tests/test_bilby.py
@@ -1,0 +1,19 @@
+"""
+Tests for the bilby interfaces
+"""
+
+import unittest
+import os
+import heron.bilby
+
+class TestBilbyData(unittest.TestCase):
+
+    def setUp(self):
+        self.current_directory = os.path.dirname(os.path.realpath(__file__))
+        self.data_directory = os.path.join(self.current_directory, "testing-data")
+
+    def test_read_pickle(self):
+        data = heron.bilby.read_pickle(
+            os.path.join(self.data_directory, "bilby-pipe-data.pickle")
+        )
+        self.assertTrue(set(data['strain'].keys()) == {"H1", "L1"})


### PR DESCRIPTION
This MR allows heron to read strain data from a pickle file created by `bilby_pipe_generation`.

