### PR TITLE
Update the htcondor bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+environment/
+
 # Images
 *.png
 *.jpg

--- a/heron/asimov/__init__.py
+++ b/heron/asimov/__init__.py
@@ -4,10 +4,21 @@ import os
 import configparser
 import glob
 import shutil
+import warnings
 
 import asimov.pipeline
 from asimov import config
-import htcondor
+
+# HTCondor import with fallback support for both htcondor2 and htcondor
+try:
+    warnings.filterwarnings("ignore", module="htcondor2")
+    import htcondor2 as htcondor  # NoQA
+    import classad2 as classad  # NoQA
+except ImportError:
+    warnings.filterwarnings("ignore", module="htcondor")
+    import htcondor  # NoQA
+    import classad  # NoQA
+
 from asimov.utils import set_directory
 from ..utils import make_metafile
 

--- a/heron/asimov/__init__.py
+++ b/heron/asimov/__init__.py
@@ -12,11 +12,9 @@ from asimov import config
 try:
     warnings.filterwarnings("ignore", module="htcondor2")
     import htcondor2 as htcondor  # NoQA
-    import classad2 as classad  # NoQA
 except ImportError:
     warnings.filterwarnings("ignore", module="htcondor")
     import htcondor  # NoQA
-    import classad  # NoQA
 
 from asimov.utils import set_directory
 from ..utils import make_metafile
@@ -76,6 +74,12 @@ class MetaPipeline(asimov.pipeline.Pipeline):
 
     def submit_dag(self, dryrun=False):
         """Submit the job to the cluster. For MetaPipeline, submission happens in build_dag."""
+        if dryrun:
+            # No additional submission happens here; build_dag has already honored dryrun.
+            if hasattr(self, "logger"):
+                self.logger.info(
+                    "Dry run: submit_dag called, but MetaPipeline submits only in build_dag."
+                )
         if hasattr(self, 'clusterid') and self.clusterid is not None:
             return self.clusterid
         else:


### PR DESCRIPTION
This MR updates the bindings between htcondor and heron to allow heron to submit jobs on clusters using the htcondor2 python interface.